### PR TITLE
Updated transpiler.js to only set up environment on yul-log init and compile functions on yul-log command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ npm install -g yul-log
 
 (sudo may be required depending on settings for a global installation)
 
+
+Once you have yul-log installed on your machine, you can run the following command to quickly set up a new Yul+ project.
+
+```
+yul-log init
+```
+
+(sudo may be required depending on settings for a global installation)
+
+
 ## Commands
 
 ```

--- a/README.md
+++ b/README.md
@@ -17,15 +17,13 @@ npm install -g yul-log
 (sudo may be required depending on settings for a global installation)
 
 
-Once you have yul-log installed on your machine, you can run the following command to quickly set up a new Yul+ project.
+After installing the package, run the following command to set up the development environment. 
 
 ```
 yul-log init
 ```
 
-(sudo may be required depending on settings for a global installation)
-
-
+Now you are all set up and can write 
 ## Commands
 
 ```
@@ -64,7 +62,7 @@ This will compile .yulp contracts inside of a "Yul+ Contracts" Directory at the 
         },
 ```
 
-so that you can compile Yul, as this will be used to compile the transpiled Yul, giving you more control over options and optimizations.
+so that you can compile Yul, as this will be used to compile the transpiled Yul, giving you more control over options and optimizations. After compiling the contract into truffle artifacts, you can run `truffle test` to run tests with truffle as normal.
 
 ```
 yul-log hardhat

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ After installing the package, run the following command to set up the developmen
 yul-log init
 ```
 
-Now you are all set up and can write 
+Now you are all set up and can write `.yulp` files inside of the `Yul+ Contracts` directory.
 ## Commands
 
 ```

--- a/transpile.js
+++ b/transpile.js
@@ -23,6 +23,8 @@ var args = process.argv.slice(2);
 if (args.length==1 && args[0]=="init"){
   console.log("Initializing yul-log...")
   yulLogInit();
+}else{
+  yulLog();
 }
 
 //initialize the yul-log environment
@@ -52,7 +54,8 @@ exec("yul-log truffle",
 
 }
 
-
+//function to compile yulp contracts
+function yulLog(){
 fs.readdir("./Yul+ Contracts/", (err, files) => {
     files.forEach(file => {
         fs.readFile("./Yul+ Contracts/" +file, 'utf8', function (err,data) {
@@ -199,3 +202,4 @@ fs.readdir("./Yul+ Contracts/", (err, files) => {
     });
   });
 })
+}


### PR DESCRIPTION
There was an error happening when initializing a new project with `yul-log init` because the transpiler.js file was running the logic to compile contracts, even though the dev environment was not set up yet. 

So now with these changes, the `yul-log init` command sets up the environment without compiling anything. Then to compile contracts, you can run `yul-log` after the environment is set up. I have updated the readme to reflect this.

Let me know if you have any thoughts!